### PR TITLE
Fix Connectivity

### DIFF
--- a/src/main/java/com/nu/art/cyborg/modules/InternetConnectivityModule.java
+++ b/src/main/java/com/nu/art/cyborg/modules/InternetConnectivityModule.java
@@ -101,6 +101,7 @@ public class InternetConnectivityModule
 						logWarning("Will retry ping in " + RETRY_DELAY + " ms. Retry count=" + retryCount);
 						retryCount++;
 						handler.postDelayed(this, RETRY_DELAY);
+						return;
 					}
 					else {
 						logError("connectivity: not connected to internet - Reached maximum retries: " + retryCount, e);

--- a/src/main/java/com/nu/art/cyborg/modules/InternetConnectivityModule.java
+++ b/src/main/java/com/nu/art/cyborg/modules/InternetConnectivityModule.java
@@ -46,12 +46,12 @@ public class InternetConnectivityModule
 		void onInternetConnectivityChanged();
 	}
 
-
 	private static final int MAX_RETRIES = 5;
 	private static final int RETRY_DELAY = 1500;
 	private int timeout = 5000;
 	private Handler handler;
 	private volatile Boolean isConnected;
+	private ConnectivityCheckRunnable connectivityCheckRunnable = new ConnectivityCheckRunnable();
 
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
@@ -74,11 +74,22 @@ public class InternetConnectivityModule
 
 	private void checkInternetConnectionAsync() {
 		logVerbose("checkInternetConnectionAsync");
-		handler.post(new ConnectivityCheckRunnable());
+		handler.removeCallbacks(connectivityCheckRunnable);
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				connectivityCheckRunnable.reset();
+			}
+		});
+		handler.post(connectivityCheckRunnable);
 	}
 
 	private class ConnectivityCheckRunnable implements Runnable {
-		private int retryCount = 0;
+		private int retryCount;
+
+		public void reset(){
+			retryCount = 0;
+		}
 
 		@Override
 		public void run() {


### PR DESCRIPTION
When losing connection and reconnecting, even though the device is connected
it sometimes needs some time before it can ping 8.8.8.8 successfully.
Because of this a lot of time the resolution is "no connection" even
though device is connected.

Fix:
When receiving connectivity change, check connectivity state and only if connected
try pinging 8.8.8.8. If ping fails, retry every 1.5sec upto 5 times