### PR TITLE
Add new optional Converter_WithReusableBitmap in ImageDownloader

### DIFF
--- a/src/main/java/com/nu/art/cyborg/modules/downloader/ImageDownloaderModule.java
+++ b/src/main/java/com/nu/art/cyborg/modules/downloader/ImageDownloaderModule.java
@@ -35,6 +35,8 @@ import com.nu.art.cyborg.modules.CacheModule.Cacheable;
 import com.nu.art.cyborg.modules.downloader.GenericDownloaderModule.Downloader;
 import com.nu.art.cyborg.modules.downloader.GenericDownloaderModule.DownloaderBuilder;
 import com.nu.art.cyborg.modules.downloader.converters.Converter_Bitmap;
+import com.nu.art.cyborg.modules.downloader.converters.Converter_ImmutableBitmap;
+import com.nu.art.cyborg.modules.downloader.converters.Converter_WithReusableBitmap;
 
 import java.lang.ref.WeakReference;
 
@@ -73,6 +75,8 @@ public class ImageDownloaderModule
 		ImageDownloaderBuilder setPostDownloading(Function<Bitmap, Bitmap> postDownloading);
 
 		ImageDownloaderBuilder setCacheable(Cacheable cacheable);
+
+		ImageDownloaderBuilder setInBitmap(Bitmap bitmap);
 
 		ImageDownloaderBuilder setCacheable(String cacheToFolder, String suffix, boolean isMust);
 
@@ -120,9 +124,15 @@ public class ImageDownloaderModule
 		private Processor<Bitmap> onSuccess;
 		private Runnable onAfter;
 		private Processor<Throwable> onError;
+		private Converter_Bitmap converter = Converter_ImmutableBitmap.converter;
 
 		private void setTarget(ImageView target) {
 			this.target = new WeakReference<>(target);
+		}
+
+		public ImageDownloaderBuilder setInBitmap(Bitmap bitmap) {
+			this.converter = new Converter_WithReusableBitmap(bitmap);
+			return this;
 		}
 
 		private void setUrl(String url) {
@@ -229,7 +239,7 @@ public class ImageDownloaderModule
 			downloaderBuilder.onBefore(onBefore);
 			downloaderBuilder.onAfter(onAfter);
 			downloaderBuilder.setDownloader(downloader);
-			downloaderBuilder.onSuccess(Converter_Bitmap.converter, new Processor<Bitmap>() {
+			downloaderBuilder.onSuccess(converter, new Processor<Bitmap>() {
 
 				@Override
 				public void process(Bitmap bitmap) {

--- a/src/main/java/com/nu/art/cyborg/modules/downloader/ImageDownloaderModule.java
+++ b/src/main/java/com/nu/art/cyborg/modules/downloader/ImageDownloaderModule.java
@@ -78,6 +78,8 @@ public class ImageDownloaderModule
 
 		ImageDownloaderBuilder setInBitmap(Bitmap bitmap);
 
+		ImageDownloaderBuilder setBitmapConverter(Converter_Bitmap converter);
+
 		ImageDownloaderBuilder setCacheable(String cacheToFolder, String suffix, boolean isMust);
 
 		ImageDownloaderBuilder onSuccess(Processor<Bitmap> onSuccess);
@@ -132,6 +134,12 @@ public class ImageDownloaderModule
 
 		public ImageDownloaderBuilder setInBitmap(Bitmap bitmap) {
 			this.converter = new Converter_WithReusableBitmap(bitmap);
+			return this;
+		}
+
+		@Override
+		public ImageDownloaderBuilder setBitmapConverter(Converter_Bitmap converter) {
+			this.converter = converter;
 			return this;
 		}
 

--- a/src/main/java/com/nu/art/cyborg/modules/downloader/converters/Converter_ImmutableBitmap.java
+++ b/src/main/java/com/nu/art/cyborg/modules/downloader/converters/Converter_ImmutableBitmap.java
@@ -19,8 +19,9 @@
 package com.nu.art.cyborg.modules.downloader.converters;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 
-import com.nu.art.core.generics.Function;
+import com.nu.art.core.exceptions.runtime.ThisShouldNotHappenException;
 
 import java.io.InputStream;
 
@@ -29,7 +30,17 @@ import java.io.InputStream;
  */
 
 @SuppressWarnings("unused")
-public interface  Converter_Bitmap
-	extends Function<InputStream, Bitmap> {
+public class Converter_ImmutableBitmap
+	implements Converter_Bitmap {
 
+	public static final Converter_ImmutableBitmap converter = new Converter_ImmutableBitmap();
+
+	@Override
+	public Bitmap map(InputStream inputStream) {
+		Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
+		if (bitmap == null)
+			throw new ThisShouldNotHappenException("Could not create bitmap from input stream");
+
+		return bitmap;
+	}
 }

--- a/src/main/java/com/nu/art/cyborg/modules/downloader/converters/Converter_WithReusableBitmap.java
+++ b/src/main/java/com/nu/art/cyborg/modules/downloader/converters/Converter_WithReusableBitmap.java
@@ -1,0 +1,57 @@
+/*
+ * cyborg-core is an extendable  module based framework for Android.
+ *
+ * Copyright (C) 2018  Adam van der Kruk aka TacB0sS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nu.art.cyborg.modules.downloader.converters;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import com.nu.art.core.exceptions.runtime.ThisShouldNotHappenException;
+
+import java.io.InputStream;
+
+@SuppressWarnings("unused")
+public class Converter_WithReusableBitmap
+	implements Converter_Bitmap {
+
+	private BitmapFactory.Options options;
+
+	/**
+	 * @param inBitmap, the bitmap object to override with the new image. Can be null.
+	 */
+	public Converter_WithReusableBitmap(Bitmap inBitmap) {
+		options = new BitmapFactory.Options();
+		options.inMutable = true;
+		options.inSampleSize = 1;
+		options.inBitmap = inBitmap;
+	}
+
+	/**
+	 * @param inputStream the stream of bytes of the image.
+	 *
+	 * @return a new bitmap object if inBitmap was null, or the inBitmap provided with new content.
+	 */
+	@Override
+	public Bitmap map(InputStream inputStream) {
+		Bitmap bitmap = BitmapFactory.decodeStream(inputStream, null, options);
+		if (bitmap == null)
+			throw new ThisShouldNotHappenException("Could not create bitmap from input stream");
+
+		return bitmap;
+	}
+}


### PR DESCRIPTION
Each instance of the converted  will work with the same bitmap object,
therefore can only be used when replacing an image by downloadeding
another one of the same dimentions