### PR TITLE
Avoid release the surface of a VideoView, if the VideoView wasn't ini…

### DIFF
--- a/src/main/java/com/nu/art/cyborg/ui/views/VideoView.java
+++ b/src/main/java/com/nu/art/cyborg/ui/views/VideoView.java
@@ -135,7 +135,8 @@ public class VideoView
 		super.onDetachedFromWindow();
 		if (mediaPlayer != null)
 			mediaPlayer.dispose();
-		surface.release();
+		if (surface != null)
+			surface.release();
 	}
 
 	@Override


### PR DESCRIPTION
…tialized, thus a surface wasn't created.